### PR TITLE
fix: use `html_url` instead of `url` for projects

### DIFF
--- a/cv.json
+++ b/cv.json
@@ -124,7 +124,7 @@
       "endDate": "2024"
     },
     {
-      "institution": "Sastra University",
+      "institution": "SASTRA University",
       "url": "http://sastra.edu/",
       "area": "Computer Science",
       "studyType": "Bachelor",

--- a/cv.json
+++ b/cv.json
@@ -125,7 +125,7 @@
     },
     {
       "institution": "SASTRA University",
-      "url": "http://sastra.edu/",
+      "url": "https://sastra.edu/",
       "area": "Computer Science",
       "studyType": "Bachelor",
       "startDate": "2013",

--- a/src/components/sections/Projects.astro
+++ b/src/components/sections/Projects.astro
@@ -13,7 +13,7 @@ const myGithubProjects = await fetchAllProjects(projects);
   <div class="grid grid-cols-1 gap-3 md:grid-cols-2 print:flex print:flex-col">
     {
       myGithubProjects.map(
-        ({ project: { name, url, description }, languages }) => {
+        ({ project: { name, html_url, description }, languages }) => {
           return (
             <div
               role="contentinfo"
@@ -27,7 +27,7 @@ const myGithubProjects = await fetchAllProjects(projects);
                 </div>
 
                 <a
-                  href={url}
+                  href={html_url}
                   title="View Source Code"
                   target="_blank"
                   rel="noopener"


### PR DESCRIPTION
In the projects section of the homepage, link to the human-readable HTML URL rather than the machine-consumable API URL